### PR TITLE
new: add support for using environment variables in configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f75e6f2b03d9292f6e18aaeeda21d58c91f6943a58ea19a2e8672dcf9d91d5b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1254,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "jsonschema",
+ "minijinja",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -52,6 +52,14 @@ Webhook type:
 > \*\* This MUST be an http or https url! You need to include the scheme as a part of the URL
 > \*\*\* Retries use an exponential backoff with jitter to prevent Pixy from spamming downstream targets
 
+#### Using Environment Variables in your Config File
+
+Some information might be more sensitive and should not be written into your `pixy.yaml` file, or should otherwise be passed in at runtime. For these cases, it would be best to reference this external information in some way.
+
+Pixy supports this by making available all environment variables that start with the prefix `"PIXY_"` to your config. This uses [jinja-like syntax](https://docs.rs/minijinja/latest/minijinja/syntax/index.html) provided by `minijinja`, exposing only the `env` variable.
+
+An example of using the environment variable in configuration can be found [here](/example-configs/environment-variables.yaml). Note that the `PIXY_` prefix is removed, so setting the `PIXY_RETRIES` environment variable will make it available for the config under `{{ env.RETRIES }}`
+
 ### Setting up the Enviro Pico
 
 Compatible boards:

--- a/example-configs/environment-variables.yaml
+++ b/example-configs/environment-variables.yaml
@@ -1,0 +1,6 @@
+targets:
+  - name: "Pixy echo server"
+    webhook:
+      url: "http://localhost:9147/echo"
+      retries: {{ env.RETRIES }}
+      timeout: 1

--- a/pixy-core/Cargo.toml
+++ b/pixy-core/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.175", features = ["derive"] }
 serde_json = "1.0.103"
 jsonschema = { version = "0.17.1", default-features = false, features = ["resolve-file"] }
 serde_yaml = { version = "0.9.25"}
+minijinja = { version = "1.0.5", default-features = false, features = ["macros"] }
 
 
 

--- a/pixy-core/src/lib.rs
+++ b/pixy-core/src/lib.rs
@@ -110,8 +110,8 @@ impl Gateway for SensorGateway {
         debug!("Handling reading: {:?}", &reading);
 
         for handler in &self.handlers {
-            let _ = handler.handle_reading(&reading).await.map_err(|e| {
-                tracing::error!("Error handling reading: {}", e);
+            let _ = handler.handle_reading(&reading).await.map_err(|_| {
+                tracing::error!(?handler, "Handler produced error");
             });
         }
     }

--- a/pixy-core/src/validation.rs
+++ b/pixy-core/src/validation.rs
@@ -1,7 +1,9 @@
 use crate::config::ConfigFile;
 
-use std::fs::File;
+use std::{collections::HashMap, env};
 use tracing::debug;
+
+use minijinja::{context, Environment};
 
 pub const GATEWAY_SCHEMA: &str = include_str!("../schemas/gateway.schema.json");
 
@@ -32,10 +34,27 @@ fn validate_config(config_value: &serde_json::Value) -> Result<(), String> {
 pub fn parse_configs(file_name: &str) -> Result<ConfigFile, String> {
     debug!("Validating file: {}", file_name);
 
-    let file_handler = File::open(file_name).map_err(|e| format!("Error opening file: {}", e))?;
+    let config_text =
+        std::fs::read_to_string(file_name).map_err(|e| format!("Error reading file: {}", e))?;
+
+    let mut env = Environment::new();
+
+    env.add_template("pixy", &config_text)
+        .map_err(|e| format!("Error adding template to environment: {}", e))?;
+
+    let env_vars: HashMap<String, String> = env::vars()
+        .filter(|(key, _)| key.starts_with("PIXY_"))
+        .map(|(key, val)| (key.replace("PIXY_", ""), val))
+        .collect();
+
+    let rendered = env
+        .get_template("pixy")
+        .map_err(|e| format!("Error getting template: {}", e))?
+        .render(context!(env => env_vars))
+        .map_err(|e| format!("Error rendering template: {}", e))?;
 
     let config: serde_json::Value =
-        serde_yaml::from_reader(file_handler).map_err(|e| format!("Error parsing YAML: {}", e))?;
+        serde_yaml::from_str(&rendered).map_err(|e| format!("Error parsing YAML: {}", e))?;
 
     validate_config(&config)?;
 


### PR DESCRIPTION
This PR adds support for pulling environment variables prefixed with `PIXY_` into the configuration file `pixy.yaml`. This allows for referencing runtime-available information from the environment in the config file, which is also useful for sensitive information such as passwords/API tokens/etc.

Closes #11 