### PR TITLE
add webhook authentication and support for context objects

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   PACKAGE_NAME: pixy
-  VERSION: 0.1.${{ github.run_number }}
+  VERSION: "0.2.0"
 
 on:
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f75e6f2b03d9292f6e18aaeeda21d58c91f6943a58ea19a2e8672dcf9d91d5b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1254,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "jsonschema",
+ "minijinja",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -15,42 +15,13 @@ For Docker installations, configuration is done through environment variables:
 | PIXY_CONFIG_FILE | /pixy.yaml | The location of the config file                                      |
 | PIXY_ENABLE_ECHO | false      | Whether or not to enable the `/echo` route.                          |
 
-### Writing a `pixy.yaml` File
-
 The most crucial thing to know before configuring Pixy targets is where the configuration file lives.
 
 - If installed using the `.deb` packages, the Pixy service will read from `/etc/pixy/pixy.yaml`. After changing your configuration, make sure to check it with `pixy validate -c /etc/pixy/pixy.yaml`, and apply your configurations by restarting the service with `sudo systemctl restart pixy.service`
-- If installed using Docker, the Pixy service will look for a `/pixy.yaml` file on the container. You need to mount the file into the container.
+- If installed using Docker, the Pixy service will look for a `/pixy.yaml` file on the container. You will need to mount the file into the container.
 - The Pixy CLI will look for a `pixy.yaml` file at the current directory
 
-Below are tables describing the various types and fields allowed in the config file.
-
-Config file:
-
-| Key     | Type         | Default | Description                                                | Required |
-| ------- | ------------ | ------- | ---------------------------------------------------------- | -------- |
-| targets | list[Target] | n/a     | All the targets that Pixy should export the sensor data to | yes      |
-
-Target type:
-
-| Key       | Type    | Default | Description                            | Required |
-| --------- | ------- | ------- | -------------------------------------- | -------- |
-| name      | string  | n/a     | The name of the upload target          | yes      |
-| enabled   | bool    | true    | Whether or not this target is enabled  | no       |
-| webhook\* | Webhook | n/a     | The configuration for a webhook target | yes      |
-
-> Keys with \* cannot be combined; only one can be specified per target
-
-Webhook type:
-
-| Key           | Type       | Default | Description                                                         | Required |
-| ------------- | ---------- | ------- | ------------------------------------------------------------------- | -------- |
-| url\*\*       | url        | n/a     | The URL to post the sensor data to                                  | yes      |
-| timeout       | int (1-60) | 10      | The number of seconds to wait before timing out a request as failed | no       |
-| retries\*\*\* | int (0-10) | 3       | The number of retries when requests fail                            | no       |
-
-> \*\* This MUST be an http or https url! You need to include the scheme as a part of the URL
-> \*\*\* Retries use an exponential backoff with jitter to prevent Pixy from spamming downstream targets
+Example configuration files showing different ways that a `pixy.yaml` file can be configured are available [here](/example-configs/). For a full breakdown of all the types supported by the configuration, see the [types document](/docs/Types.md).
 
 ### Setting up the Enviro Pico
 

--- a/docs/ContextObjects.md
+++ b/docs/ContextObjects.md
@@ -1,0 +1,55 @@
+# Context Objects
+
+## Using Context Objects
+
+Sometimes it is important to use information that you don't want to directly hardcode in your `pixy.yaml` file, or use data that depends on the information sent to Pixy by the sensors. One example of this is passwords- storing passwords in the configuration file itself is considered to be an unsafe practice, especially since configuration files tend to be stored in things like Github.
+
+Examples of configurations using context objects can be found [here](/example-configs/webhook.yaml), or a minimal example is shown below for a webhook target.
+
+```yaml
+targets:
+  - name: "A basic webhook target"
+    webhook:
+      url: "http://localhost:9147/echo"
+      auth:
+        token: "{{ env.TOKEN }}"
+```
+
+## Supported Context Objects
+
+Below are all the context objects currently supported. These can be used anywhere that context objects are supported.
+
+| Name      | Description                                                                            |
+| --------- | -------------------------------------------------------------------------------------- |
+| `env`     | Contains all environment variables that are prefixed with `PIXY_`, removing the prefix |
+| `message` | A [SensorMessage](#sensormessage) containing information sent in the messsage to Pixy  |
+
+## Context Object Types
+
+### SensorMessage
+
+| Key       | Type                                | Description                                            | Nullable |
+| --------- | ----------------------------------- | ------------------------------------------------------ | -------- |
+| readings  | [Reading](#reading)                 | The values recorded by the sensors                     | no       |
+| timestamp | string                              | The time the reading was taken                         | no       |
+| metadata  | [MessageMetadata](#messagemetadata) | Information about the device that produced the message | no       |
+
+### Reading
+
+| Key               | Type | Description                          | Nullable |
+| ----------------- | ---- | ------------------------------------ | -------- |
+| temperature       | f32  | A temperature reading, in Celsius    | no       |
+| pressure          | f32  | The pressure reading, in hPa         | no       |
+| humidity          | f32  | The humidity, in relative percentage | no       |
+| color_temperature | u64  | The color temperature, in Kelvin     | yes      |
+| gas_resistance    | u64  | The gas resistance, in Ohms          | yes      |
+| aqi               | f32  | The Indoor Air Quality score         | yes      |
+| luminance         | u64  | The luminance, in lux                | yes      |
+
+### MessageMetadata
+
+| Key      | Type   | Description                                        | Nullable |
+| -------- | ------ | -------------------------------------------------- | -------- |
+| nickname | string | The nickname of the board that sent this message   | no       |
+| model    | string | The model name of the board that sent this message | no       |
+| uid      | string | A unique ID for the board that sent this message   | no       |

--- a/docs/Types.md
+++ b/docs/Types.md
@@ -1,0 +1,44 @@
+# Types
+
+Below are tables describing types used for context objects and the `pixy.yaml` configuration file.
+
+## Configuration Types
+
+### Config
+
+| Key     | Type                    | Default | Description                                                | Required |
+| ------- | ----------------------- | ------- | ---------------------------------------------------------- | -------- |
+| targets | list[[Target](#target)] | n/a     | All the targets that Pixy should export the sensor data to | yes      |
+
+### Target
+
+| Key       | Type                | Default | Description                            | Required |
+| --------- | ------------------- | ------- | -------------------------------------- | -------- |
+| name      | string              | n/a     | The name of the upload target          | yes      |
+| enabled   | bool                | true    | Whether or not this target is enabled  | no       |
+| webhook\* | [Webhook](#webhook) | n/a     | The configuration for a webhook target | yes      |
+
+> Keys with \* cannot be combined; only one can be specified per target
+
+### Webhook
+
+| Key         | Type                        | Default | Description                                                         | Required |
+| ----------- | --------------------------- | ------- | ------------------------------------------------------------------- | -------- |
+| url\*       | string                      | n/a     | The URL to post the sensor data to                                  | yes      |
+| timeout     | int (1-60)                  | 10      | The number of seconds to wait before timing out a request as failed | no       |
+| retries\*\* | int (0-10)                  | 3       | The number of retries when requests fail                            | no       |
+| auth        | [WebhookAuth](#webhookauth) | n/a     | Authentication to use with the webhook, if necessary                | no       |
+
+> \* This MUST be an http or https url! You need to include the scheme as a part of the URL
+> \*\* Retries use an exponential backoff with jitter to prevent Pixy from spamming downstream targets
+
+#### WebhookAuth
+
+| Key      | Type     | Default | Description                         | Required |
+| -------- | -------- | ------- | ----------------------------------- | -------- |
+| username | string\* | n/a     | The username to use for Basic Auth. | yes\*\*  |
+| password | string\* | n/a     | The password to use for Basic Auth. | yes\*\*  |
+| token    | string\* | n/a     | The token to use for Bearer Auth    | yes\*\*  |
+
+> \* These types support using [context objects](/docs/ContextObjects.md).
+> \*\* Only one authentication type can be used. If using Basic Auth, set both `username` and `password`. If using Bearer, only set `token`.

--- a/example-configs/webhook.yaml
+++ b/example-configs/webhook.yaml
@@ -1,0 +1,61 @@
+targets:
+  # This covers the basic example; an enabled
+  # webhook with no auth, using all the other defaults.
+  # This will retry 3 times on failure, and request timeout
+  # is 10 seconds
+  - name: "Basic webhook to echo server"
+    webhook:
+      url: "http://localhost:9147/echo"
+
+  # This example explicitly sets the retries to 5, and
+  # sets the timeout to 30 seconds instead of 10,
+  # which is useful if we expect this target to be
+  # more flaky than others.
+  - name: "Basic webhook with retries"
+    webhook:
+      url: "http://localhost:9147/echo"
+      retries: 5
+      timeout: 30
+
+  # This example uses basic authentication. The username
+  # is hardcoded, but the password is pulled from an
+  # environment variable at runtime. It is recommended
+  # to use environment variables for sensitive data,
+  # and to not store them in the config file, but this
+  # is not enforced; you can hardcode the password if
+  # you want.
+  - name: "Webhook using basic auth"
+    webhook:
+      url: "http://localhost:9147/echo"
+      auth:
+        username: "pixy"
+        # This value is pulled from the environment variable
+        # `PIXY_PASSWORD`
+        password: "{{ env.PASSWORD }}"
+
+  # This example uses bearer authentication. The token
+  # is pulled from an environment variable at runtime.
+  # It is recommended to use environment variables for
+  # sensitive data, and to not store them in the config
+  # file, but this is not enforced; you can hardcode the
+  # token if you want.
+  - name: "Webhook using bearer auth"
+    webhook:
+      url: "http://localhost:9147/echo"
+      auth:
+        # This value is pulled from the environment variable
+        # `PIXY_TOKEN`
+        token: "{{ env.TOKEN }}"
+
+  # This is a second example of a webhook using bearer auth,
+  # but using a different environment variable for the token.
+  # You can use as many different environment variables as
+  # you want, provided that they use different names and
+  # start with `PIXY_`.
+  - name: "Second webhook using bearer auth and environment variables"
+    webhook:
+      url: "http://localhost:9147/echo"
+      auth:
+        # This value is pulled from the environment variable
+        # `PIXY_OTHER_TOKEN`
+        token: "{{ env.OTHER_TOKEN }}"

--- a/pixy-core/Cargo.toml
+++ b/pixy-core/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.175", features = ["derive"] }
 serde_json = "1.0.103"
 jsonschema = { version = "0.17.1", default-features = false, features = ["resolve-file"] }
 serde_yaml = { version = "0.9.25"}
+minijinja = { version = "1.0.5", default-features = false, features = ["macros"] }
 
 
 

--- a/pixy-core/schemas/gateway.schema.json
+++ b/pixy-core/schemas/gateway.schema.json
@@ -68,6 +68,29 @@
           "minimum": 0,
           "maximum": 10,
           "examples": [0, 1, 3, 5, 10]
+        },
+        "auth": {
+          "type": "object",
+          "description": "The authentication to use for the webhook",
+          "properties": {
+            "username": {
+              "type": "string",
+              "description": "The username to use for basic authentication"
+            },
+            "password": {
+              "type": "string",
+              "description": "The password to use for basic authentication"
+            },
+            "token": {
+              "type": "string",
+              "description": "The bearer token to use for bearer authentication"
+            }
+          },
+          "oneOf": [
+            { "required": ["username", "password"] },
+            { "required": ["token"] }
+          ],
+          "additionalProperties": false
         }
       }
     }

--- a/pixy-core/src/config.rs
+++ b/pixy-core/src/config.rs
@@ -37,6 +37,16 @@ pub struct WebhookTargetProperties {
 
     #[serde(default = "_default_timeout")]
     pub timeout: u8,
+
+    #[serde(default)]
+    pub auth: Option<WebhookAuth>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WebhookAuth {
+    Basic { username: String, password: String },
+    Bearer { token: String },
 }
 
 fn _default_retries() -> u8 {
@@ -49,4 +59,18 @@ fn _default_timeout() -> u8 {
 
 fn _default_true() -> bool {
     true
+}
+
+impl std::fmt::Debug for WebhookAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WebhookAuth::Basic {
+                username: _,
+                password: _,
+            } => {
+                write!(f, "Basic {{ username: ******, password: ****** }}")
+            }
+            WebhookAuth::Bearer { token: _ } => write!(f, "Bearer {{ token: ******* }}"),
+        }
+    }
 }

--- a/pixy-core/src/handlers/webhook.rs
+++ b/pixy-core/src/handlers/webhook.rs
@@ -5,9 +5,11 @@ use std::time::Duration;
 use async_trait::async_trait;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
-use tracing::instrument;
+use tracing::{debug, error, info, instrument};
 
-use crate::config::{Target, TargetProperties::Webhook, WebhookTargetProperties};
+use minijinja::{value::Value, Environment};
+
+use crate::config::{Target, TargetProperties::Webhook, WebhookAuth, WebhookTargetProperties};
 
 #[derive(Debug)]
 pub struct WebhookHandler {
@@ -52,15 +54,58 @@ impl From<Target> for WebhookHandler {
 #[async_trait]
 impl SensorHandler for WebhookHandler {
     #[instrument]
-    async fn handle_reading(&self, reading: &SensorMessage) -> Result<(), String> {
-        tracing::info!("Sending reading data to {}", &self.config.url);
-        let response = self
+    async fn handle_reading(&self, reading: &SensorMessage, context: &Value) -> Result<(), String> {
+        info!(config = ?self.config, "Sending reading data to {}", &self.config.url);
+        let request = self
             .client
             .post(&self.config.url)
             .timeout(Duration::from_secs(self.config.timeout as u64))
-            .json(reading)
+            .json(reading);
+
+        let env = Environment::new();
+
+        let request = if let Some(auth) = &self.config.auth {
+            match auth {
+                WebhookAuth::Basic { username, password } => {
+                    let username = env.render_str(username, context).map_err(|e| {
+                        tracing::error!("Error rendering username: {}", e);
+                        e.to_string()
+                    })?;
+                    let password = env.render_str(password, context).map_err(|e| {
+                        tracing::error!("Error rendering password: {}", e);
+                        e.to_string()
+                    })?;
+                    request.basic_auth(username, Some(password))
+                }
+                WebhookAuth::Bearer { token } => {
+                    request.bearer_auth(env.render_str(token, context).map_err(|e| {
+                        tracing::error!("Error rendering token: {}", e);
+                        e.to_string()
+                    })?)
+                }
+            }
+        } else {
+            request
+        };
+
+        let response = request
             .send()
-            .await;
+            .await
+            .and_then(|r| match r.error_for_status() {
+                Ok(res) => Ok(res),
+                Err(e) => Err(reqwest_middleware::Error::from(e)),
+            })
+            .map(|r| {
+                debug!(response = ?r, "Successfully sent reading data");
+                info!(
+                    response_status = r.status().as_u16(),
+                    target_url = %self.config.url,
+                );
+            })
+            .map_err(|e| {
+                error!(error = ?e, "Failed to send reading data");
+                e.to_string()
+            });
 
         match response {
             Ok(_) => Ok(()),


### PR DESCRIPTION
Closes #11 

This PR is a different take on the solution than #12, and tries to answer some questions that will come up when trying to implement #1 and #7 around topic re-publishing

This restructures the handler API to pass in a context value for rendering templates, which in turn allows a specific handler to enable context objects for specific parts of its configuration (i.e. for passwords).