### PR TITLE
add more tests to various packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,13 +63,25 @@ jobs:
             name: "amd64"
           - target: "aarch64-unknown-linux-musl"
             name: "arm64"
-          - target: "armv7-unknown-linux-musleabihf"
+          - target: "armv7-unknown-linux-musleabi"
             name: "armv7"
+          - target: "armv7-unknown-linux-musleabihf"
+            name: "armv7hf"
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-test-${{ matrix.architecture.target }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-binstall
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,8 +116,10 @@ jobs:
             name: "amd64"
           - target: "aarch64-unknown-linux-musl"
             name: "arm64"
-          - target: "armv7-unknown-linux-musleabihf"
+          - target: "armv7-unknown-linux-musleabi"
             name: "armv7"
+          - target: "armv7-unknown-linux-musleabihf"
+            name: "armv7hf"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-test-${{ matrix.architecture.target }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install cargo-binstall
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ version = "0.1.0"
 dependencies = [
  "httpmock",
  "minreq",
+ "openssl",
 ]
 
 [[package]]
@@ -1595,6 +1596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.27.0+1.1.1v"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1612,7 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1754,6 +1765,7 @@ dependencies = [
  "httpmock",
  "jsonschema",
  "minijinja",
+ "openssl",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,154 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 1.9.0",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "log",
+ "parking",
+ "polling",
+ "rustix 0.37.23",
+ "slab",
+ "socket2",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb901c30ebc2fc4ab46395bbfbdba9542c16559d853645d75190c3056caf3bc"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 0.37.23",
+ "signal-hook",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+
+[[package]]
 name = "async-trait"
 version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +267,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "autocfg"
@@ -197,6 +351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb53b6b315f924c7f113b162e53b3901c05fc9966baf84d201dfcc7432a4bb38"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +389,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "blocking"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand 1.9.0",
+ "futures-lite",
+ "log",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +420,12 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
@@ -324,6 +510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +546,94 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.65+curl-8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961ba061c9ef2fe34bbd12b807152d96f0badd2bebe7b90ce6c8c8b7572a0986"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "ena"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -389,6 +672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,9 +689,24 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -493,6 +797,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +872,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +918,7 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 name = "healthcheck"
 version = "0.1.0"
 dependencies = [
+ "httpmock",
  "minreq",
 ]
 
@@ -635,6 +967,34 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "httpmock"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b02e044d3b4c2f94936fb05f9649efa658ca788f44eb6b87554e2033fc8ce93"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper",
+ "isahc",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "hyper"
@@ -781,12 +1141,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener",
+ "futures-lite",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "polling",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
 name = "iso8601"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -833,16 +1229,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.7+1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -871,6 +1335,9 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "matchit"
@@ -961,6 +1428,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
@@ -1140,6 +1613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1677,25 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap 1.9.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1285,10 +1783,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1357,6 +1877,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,7 +1896,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1376,8 +1907,14 @@ checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1664,6 +2201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +2245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,12 +2264,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
 ]
 
 [[package]]
@@ -1736,6 +2316,19 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -1776,10 +2369,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.4",
  "windows-sys",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -1846,6 +2450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1992,6 +2605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-bag"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2740,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ name = "pixy-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "httpmock",
  "jsonschema",
  "minijinja",
  "reqwest",
@@ -1767,11 +1768,15 @@ dependencies = [
 name = "pixy-server"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "config",
+ "hyper",
  "pixy-core",
  "serde",
+ "serde_json",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2181,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",

--- a/healthcheck/Cargo.toml
+++ b/healthcheck/Cargo.toml
@@ -10,3 +10,4 @@ minreq = "2.8.1"
 
 [dev-dependencies]
 httpmock = "0.6.8"
+openssl = { version = "0.10", features = ["vendored"] }

--- a/healthcheck/Cargo.toml
+++ b/healthcheck/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 minreq = "2.8.1"
+
+[dev-dependencies]
+httpmock = "0.6.8"

--- a/healthcheck/src/main.rs
+++ b/healthcheck/src/main.rs
@@ -1,21 +1,69 @@
 use std::{env, process::ExitCode};
 
+#[inline]
+fn get(url: &str) -> bool {
+    minreq::get(url)
+        .send()
+        .map(|res| {
+            println!("Received status code {}", res.status_code);
+            res
+        })
+        .map_err(|e| println!("{}", e))
+        .is_ok_and(|res| (200..=299).contains(&res.status_code))
+}
+
 fn main() -> ExitCode {
     let port = env::var("PIXY_PORT").unwrap_or_else(|_| String::from("8000"));
     let endpoint = format!("http://localhost:{}/healthz", port);
 
-    minreq::get(endpoint)
-        .send()
-        .map(|res| {
-            if !(200..=299).contains(&res.status_code) {
-                println!("Received status code {}", res.status_code);
-                ExitCode::FAILURE
-            } else {
-                ExitCode::SUCCESS
-            }
-        })
-        .unwrap_or_else(|e| {
-            println!("{}", e);
-            ExitCode::FAILURE
-        })
+    if get(&endpoint) {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::MockServer;
+
+    fn test_get_failure(status_code: u16, success: bool) {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET);
+            then.status(status_code);
+        });
+
+        let res = get(&server.url("/healthz"));
+
+        assert_eq!(res, success);
+        mock.assert();
+    }
+
+    macro_rules! test_get {
+        ($($a:ident: $b:expr, $c:expr,)*) => {
+        mod test_get {
+                use super::*;
+            $(
+                #[test]
+                fn $a() {
+                    test_get_failure($b, $c);
+                }
+            )*
+        }
+        };
+    }
+
+    test_get!(
+        success_when_200: 200, true,
+        success_when_201: 201, true,
+        success_when_219: 219, true,
+        failure_when_300: 300, false,
+        failure_when_400: 400, false,
+        failure_when_401: 401, false,
+        failure_when_404: 404, false,
+        failure_when_500: 500, false,
+    );
 }

--- a/pixy-core/Cargo.toml
+++ b/pixy-core/Cargo.toml
@@ -31,3 +31,6 @@ default = ["rustls-tls"]
 
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+
+[dev-dependencies]
+httpmock = "0.6.8"

--- a/pixy-core/Cargo.toml
+++ b/pixy-core/Cargo.toml
@@ -34,3 +34,4 @@ rustls-tls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 httpmock = "0.6.8"
+openssl = { version = "0.10", features = ["vendored"] }

--- a/pixy-core/src/handlers/webhook.rs
+++ b/pixy-core/src/handlers/webhook.rs
@@ -20,6 +20,34 @@ pub struct WebhookHandler {
 }
 
 impl WebhookHandler {
+    /// Creates a new WebhookHandler given a target configuration and a reqwest client.
+    ///
+    /// ## Arguments
+    ///
+    /// * `target_config` - The target configuration.
+    /// * `client` - The reqwest client to use for requests.
+    ///
+    /// ## Examples
+    /// ```
+    /// use pixy_core::config::{Target, TargetProperties::Webhook, WebhookTargetProperties};
+    /// use pixy_core::handlers::WebhookHandler;
+    ///
+    /// let target = Target {
+    ///    name: "test".to_string(),
+    ///    enabled: true,
+    ///    properties: Webhook(WebhookTargetProperties {
+    ///       url: "https://example.com".to_string(),
+    ///       retries: 3,
+    ///       timeout: 5,
+    ///       auth: None,
+    ///   }),
+    /// };
+    ///
+    /// let client = reqwest::Client::new();
+    ///
+    /// let handler = WebhookHandler::new(target, client);
+    /// ```
+    ///
     #[instrument]
     pub fn new(target_config: Target, client: reqwest::Client) -> Self {
         let Webhook(properties) = target_config.properties else {
@@ -44,6 +72,31 @@ impl WebhookHandler {
 }
 
 impl From<Target> for WebhookHandler {
+    /// Creates a new WebhookHandler given a target configuration.
+    ///
+    /// ## Arguments
+    ///
+    /// * `target_config` - The target configuration.
+    ///
+    /// ## Examples
+    /// ```
+    /// use pixy_core::config::{Target, TargetProperties::Webhook, WebhookTargetProperties};
+    /// use pixy_core::handlers::WebhookHandler;
+    ///
+    /// let target = Target {
+    ///    name: "test".to_string(),
+    ///    enabled: true,
+    ///    properties: Webhook(WebhookTargetProperties {
+    ///       url: "https://example.com".to_string(),
+    ///       retries: 3,
+    ///       timeout: 5,
+    ///       auth: None,
+    ///   }),
+    /// };
+    ///
+    /// let handler = WebhookHandler::from(target);
+    /// ```
+    ///
     fn from(target_config: Target) -> Self {
         let client = clients::get_default_webhook_client();
 
@@ -119,5 +172,218 @@ impl SensorHandler for WebhookHandler {
 
     fn is_enabled(&self) -> bool {
         self.enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::{Method::POST, MockServer};
+    use minijinja::context;
+
+    const TEST_MESSAGE: &str = include_str!("../../../example-configs/test-sensor.json");
+
+    fn default_properties() -> WebhookTargetProperties {
+        WebhookTargetProperties {
+            url: "http://localhost:8080".to_string(),
+            retries: 3,
+            timeout: 10,
+            auth: None,
+        }
+    }
+
+    #[test]
+    fn test_webhook_handler_from_target() {
+        let target = Target {
+            name: "test".to_string(),
+            enabled: true,
+            properties: Webhook(default_properties()),
+        };
+
+        let handler = WebhookHandler::from(target);
+
+        assert_eq!(handler.name, "test");
+        assert_eq!(handler.config.url, "http://localhost:8080");
+        assert_eq!(handler.config.retries, 3);
+        assert_eq!(handler.config.timeout, 10);
+
+        assert!(handler.enabled);
+        assert!(handler.config.auth.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_webhook_on_simple_target() {
+        let server = MockServer::start_async().await;
+
+        let message: SensorMessage = serde_json::from_str(TEST_MESSAGE).unwrap();
+
+        let body_contents = serde_json::to_string(&message).unwrap();
+
+        let mock: httpmock::Mock<'_> = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .header("Content-Type", "application/json")
+                    .body(&body_contents);
+                then.status(200);
+            })
+            .await;
+
+        server
+            .mock_async(|when, then| {
+                when.any_request();
+                then.status(400);
+            })
+            .await;
+
+        let mut properties = default_properties();
+
+        properties.url = server.url("/");
+
+        let target = Target {
+            name: "test".to_string(),
+            enabled: true,
+            properties: Webhook(properties),
+        };
+
+        let handler = WebhookHandler::from(target);
+
+        let result = handler.handle_reading(&message, &context!()).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_webhook_with_basic_auth() {
+        let server = MockServer::start_async().await;
+
+        let message: SensorMessage = serde_json::from_str(TEST_MESSAGE).unwrap();
+
+        let body_contents = serde_json::to_string(&message).unwrap();
+
+        let mock: httpmock::Mock<'_> = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+                    .body(&body_contents);
+                then.status(200);
+            })
+            .await;
+
+        server
+            .mock_async(|when, then| {
+                when.any_request();
+                then.status(400);
+            })
+            .await;
+
+        let mut properties = default_properties();
+
+        properties.url = server.url("/");
+        properties.auth = Some(WebhookAuth::Basic {
+            username: "username".to_string(),
+            password: "password".to_string(),
+        });
+
+        let target = Target {
+            name: "test".to_string(),
+            enabled: true,
+            properties: Webhook(properties),
+        };
+
+        let handler = WebhookHandler::from(target);
+
+        let result = handler.handle_reading(&message, &context!()).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_webhook_with_bearer_auth() {
+        let server = MockServer::start_async().await;
+
+        let message: SensorMessage = serde_json::from_str(TEST_MESSAGE).unwrap();
+
+        let body_contents = serde_json::to_string(&message).unwrap();
+
+        let mock: httpmock::Mock<'_> = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer 123456789")
+                    .body(&body_contents);
+                then.status(200);
+            })
+            .await;
+
+        server
+            .mock_async(|when, then| {
+                when.any_request();
+                then.status(400);
+            })
+            .await;
+
+        let mut properties = default_properties();
+
+        properties.url = server.url("/");
+        properties.auth = Some(WebhookAuth::Bearer {
+            token: "123456789".to_string(),
+        });
+
+        let target = Target {
+            name: "test".to_string(),
+            enabled: true,
+            properties: Webhook(properties),
+        };
+
+        let handler = WebhookHandler::from(target);
+
+        let result = handler.handle_reading(&message, &context!()).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_webhook_client_retries() {
+        let server = MockServer::start_async().await;
+
+        let message: SensorMessage = serde_json::from_str(TEST_MESSAGE).unwrap();
+
+        let body_contents = serde_json::to_string(&message).unwrap();
+
+        let mock: httpmock::Mock<'_> = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .header("Content-Type", "application/json")
+                    .body(&body_contents);
+                then.status(500);
+            })
+            .await;
+
+        let mut properties = default_properties();
+
+        properties.url = server.url("/");
+        properties.retries = 1;
+        properties.timeout = 1;
+
+        let target = Target {
+            name: "test".to_string(),
+            enabled: true,
+            properties: Webhook(properties),
+        };
+
+        let handler = WebhookHandler::from(target);
+
+        let result = handler.handle_reading(&message, &context!()).await;
+
+        assert!(result.is_err());
+        mock.assert_hits_async(2).await;
     }
 }

--- a/pixy-server/Cargo.toml
+++ b/pixy-server/Cargo.toml
@@ -18,3 +18,9 @@ pixy-core = { path = "../pixy-core" }
 config = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.175", features = ["derive"] }
 tokio = { version = "1.29.1", features = ["rt", "rt-multi-thread", "net", "tracing", "macros"], default-features = false }
+
+[dev-dependencies]
+async-trait = "0.1.72"
+tower = { version = "0.4", features = ["util"] }
+hyper = { version = "0.14", features = ["full"] }
+serde_json = "1.0.104"

--- a/pixy-server/src/lib.rs
+++ b/pixy-server/src/lib.rs
@@ -13,21 +13,24 @@ use crate::config::ServerConfiguration;
 use pixy_core::validation::parse_configs;
 use pixy_core::{Gateway, SensorGateway, SensorMessage};
 
-pub async fn run_server_with(server_configs: ServerConfiguration) {
-    let pixy_configs = parse_configs(&server_configs.config_file).unwrap();
-
-    let gateway: Arc<dyn Gateway> = Arc::new(SensorGateway::from(pixy_configs));
-
+fn create_app(gateway: Arc<dyn Gateway>, server_configs: &ServerConfiguration) -> axum::Router {
     let app = axum::Router::new()
         .route("/data", post(handler))
         .route("/healthz", get(|| async { StatusCode::OK }))
         .with_state(gateway);
 
-    let app = if server_configs.enable_echo {
+    if server_configs.enable_echo {
         app.route("/echo", post(echo))
     } else {
         app
-    };
+    }
+}
+
+pub async fn run_server_with_gateway(
+    gateway: Arc<dyn Gateway>,
+    server_configs: ServerConfiguration,
+) {
+    let app = create_app(gateway, &server_configs);
 
     let bind_address = format!("0.0.0.0:{}", server_configs.port);
 
@@ -54,6 +57,14 @@ pub async fn run_server_with(server_configs: ServerConfiguration) {
         .unwrap();
 }
 
+pub async fn run_server_with(server_configs: ServerConfiguration) {
+    let pixy_configs = parse_configs(&server_configs.config_file).unwrap();
+
+    let gateway: Arc<dyn Gateway> = Arc::new(SensorGateway::from(pixy_configs));
+
+    run_server_with_gateway(gateway, server_configs).await;
+}
+
 #[instrument]
 async fn handler(
     State(gateway): State<Arc<dyn Gateway>>,
@@ -72,4 +83,149 @@ async fn handler(
 async fn echo(data: String) -> String {
     info!("Received data: {:?}", &data);
     data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use axum::http::{self, Request};
+    use tower::ServiceExt;
+
+    #[derive(Debug)]
+    struct MockGateway {}
+
+    #[async_trait]
+    impl Gateway for MockGateway {
+        async fn handle_reading(&self, _reading: SensorMessage) {}
+    }
+
+    fn default_config() -> ServerConfiguration {
+        ServerConfiguration {
+            config_file: String::new(),
+            port: 9147,
+            log_level: String::from("info"),
+            enable_echo: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let gateway: Arc<dyn Gateway> = Arc::new(MockGateway {});
+
+        let app = create_app(gateway, &default_config());
+
+        let res = app
+            .oneshot(Request::get("/healthz").body("".into()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_echo_enabled() {
+        let mut configs = default_config();
+
+        configs.enable_echo = true;
+
+        let gateway: Arc<dyn Gateway> = Arc::new(MockGateway {});
+
+        let app = create_app(gateway, &configs);
+
+        let res = app
+            .oneshot(Request::post("/echo").body("hello".into()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::OK);
+
+        let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+
+        assert_eq!(&body[..], b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_echo_disable() {
+        let gateway: Arc<dyn Gateway> = Arc::new(MockGateway {});
+
+        let app = create_app(gateway, &default_config());
+
+        let res = app
+            .oneshot(Request::post("/echo").body("hello".into()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_example_sensor_works() {
+        let gateway: Arc<dyn Gateway> = Arc::new(MockGateway {});
+
+        let app = create_app(gateway, &default_config());
+
+        let example_sensor: SensorMessage =
+            serde_json::from_str(include_str!("../../example-configs/test-sensor.json")).unwrap();
+
+        let res = app
+            .oneshot(
+                Request::post("/data")
+                    .header("Content-Type", "application/json")
+                    .body(serde_json::to_string(&example_sensor).unwrap().into())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::ACCEPTED);
+    }
+
+    #[tokio::test]
+    async fn test_fails_if_wrong_content_type() {
+        let gateway: Arc<dyn Gateway> = Arc::new(MockGateway {});
+
+        let app = create_app(gateway, &default_config());
+
+        let example_sensor: SensorMessage =
+            serde_json::from_str(include_str!("../../example-configs/test-sensor.json")).unwrap();
+
+        let res = app
+            .oneshot(
+                Request::post("/data")
+                    .body(serde_json::to_string(&example_sensor).unwrap().into())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_malformed_sensor_fails() {
+        let gateway: Arc<dyn Gateway> = Arc::new(MockGateway {});
+
+        let app = create_app(gateway, &default_config());
+
+        let example_sensor: SensorMessage =
+            serde_json::from_str(include_str!("../../example-configs/test-sensor.json")).unwrap();
+
+        let res = app
+            .oneshot(
+                Request::post("/data")
+                    .header("Content-Type", "application/json")
+                    .body(
+                        serde_json::to_string(&example_sensor)
+                            .unwrap()
+                            .replace("temperature", "hot")
+                            .into(),
+                    )
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::UNPROCESSABLE_ENTITY);
+    }
 }


### PR DESCRIPTION
Add testing for the following packages.

`healthcheck`:
- Adds tests to show the result of the `get` request under different response status codes

`pixy-server`:
- Add basic sanity-check tests for `/healthz` endpoint and configuration tests for the `echo` endpoint
- Add test to ensure that the [test sensor](https://github.com/cryptaliagy/pixy/blob/main/example-configs/test-sensor.json) is recognized as proper formatted by the server
- Add test for malforming the test sensor (renaming "temperature" to "hot") causing a 4XX error
- Add test for missing content-type header in the client causing a 4XX error

`pixy-core`
- Add tests to ensure all example configuration files are valid and can be parsed into the config struct
- Add tests for the webhook handler:
    - Basic generating webhook handler from config struct
    - Querying external webhook is successful
    - Query external webhook with basic auth uses expected header with expected value
    - Query external webhook with bearer auth uses expected header with expected value
    - If the external webhook returns a 5XX, retries the request according to the target configuration