### PR TITLE
add binstall support

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -25,7 +25,14 @@ For more information, use `man pixy` after install.
 1. Run `sudo chmod 755 /usr/bin/pixy` to set the permissions as executable
 1. Run `pixy --version` to confirm that the executable is installed and discoverable
 
-## Installation - Cargo
+## Installation - Cargo (binstall)
+
+> Supported for pixy >= v0.2.0
+
+1. Run the command `cargo binstall pixy`
+1. Run `pixy --version` to confirm that the executable is installed and discoverable
+
+## Installation - Cargo (install)
 
 Support for this installation method is only provided for the following targets:
 

--- a/pixy/Cargo.toml
+++ b/pixy/Cargo.toml
@@ -52,3 +52,30 @@ assets = [
 ]
 maintainer-scripts = "../pkg/debian/"
 systemd-units = { enable = false }
+
+[package.metadata.binstall]
+pkg-fmt = "bin"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.amd64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.armv7-unknown-linux-gnueabi]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7{ archive-suffix }"
+
+[package.metadata.binstall.overrides.armv7-unknown-linux-gnueabihf]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7hf{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.amd64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.armv7-unknown-linux-musleabi]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7{ archive-suffix }"
+
+[package.metadata.binstall.overrides.armv7-unknown-linux-musleabihf]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7hf{ archive-suffix }"


### PR DESCRIPTION
This PR introduces support for installing Pixy using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall), which pulls directly from the Github Releases page. 

After the release of pixy 0.2.0, it will be installable with the command `cargo binstall pixy` or `cargo binstall pixy@0.2.0`. Note, this does not provide backwards-compatibility for installing 0.1.8 through `cargo-binstall`